### PR TITLE
Add ETag header in storage CORS configuration

### DIFF
--- a/js/storage.md
+++ b/js/storage.md
@@ -93,6 +93,7 @@ Following steps will enable your CORS Policy:
     <ExposeHeader>x-amz-server-side-encryption</ExposeHeader>
     <ExposeHeader>x-amz-request-id</ExposeHeader>
     <ExposeHeader>x-amz-id-2</ExposeHeader>
+    <ExposeHeader>ETag</ExposeHeader>
     <AllowedHeader>*</AllowedHeader>
 </CORSRule>
 </CORSConfiguration>


### PR DESCRIPTION
Uploading of file bigger than 5mb rely on the S3 Multipart Upload. Therefore it is needed to expose the ETag header in the CORS configuration.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.